### PR TITLE
Fix NestJS gRPC integration connection issues

### DIFF
--- a/src/services/grpc-provider.service.ts
+++ b/src/services/grpc-provider.service.ts
@@ -343,18 +343,25 @@ export class GrpcProviderService implements OnModuleInit, OnModuleDestroy {
                     reject(new Error(`Failed to bind server to ${url}: ${error.message}`));
                     return;
                 }
-
-                this.isRunning = true;
-
                 // Register any pending controller instances that were registered before server was running
                 this.registerPendingControllers()
                     .then(() => {
-                        this.logger.lifecycle('gRPC server started', {
-                            url,
-                            port,
-                            secure: this.options.secure,
-                        });
-                        resolve();
+                        try {
+                            this.server!.start();
+                            this.isRunning = true;
+                            this.logger.lifecycle('gRPC server started', {
+                                url,
+                                port,
+                                secure: this.options.secure,
+                            });
+                            resolve();
+                        } catch (startError: any) {
+                            reject(
+                                new Error(
+                                    `Failed to start gRPC server after binding: ${startError?.message ?? startError}`,
+                                ),
+                            );
+                        }
                     })
                     .catch(registerError => {
                         this.logger.error(

--- a/test/decorators/grpc-payload.decorator.test.ts
+++ b/test/decorators/grpc-payload.decorator.test.ts
@@ -1,4 +1,15 @@
 import { ExecutionContext } from '@nestjs/common';
+
+// Mock createParamDecorator to return the factory directly for easy testing
+jest.mock('@nestjs/common', () => {
+    const actual = jest.requireActual('@nestjs/common');
+    return {
+        ...actual,
+        createParamDecorator: (factory: any) => factory,
+    };
+});
+
+// Import after mock
 import { GrpcPayload, GrpcStreamPayload } from '../../src/decorators/grpc-payload.decorator';
 
 describe('GrpcPayload decorators', () => {
@@ -9,14 +20,12 @@ describe('GrpcPayload decorators', () => {
     };
 
     it('GrpcPayload extracts unary payload', () => {
-        const factory = (GrpcPayload as any).factory || GrpcPayload;
-        const result = factory(null, mockExecutionContext({ foo: 'bar' }));
+        const result = (GrpcPayload as any)(null, mockExecutionContext({ foo: 'bar' }));
         expect(result).toEqual({ foo: 'bar' });
     });
 
     it('GrpcStreamPayload extracts stream payload', () => {
-        const factory = (GrpcStreamPayload as any).factory || GrpcStreamPayload;
-        const result = factory(null, mockExecutionContext({ chunk: 1 }));
+        const result = (GrpcStreamPayload as any)(null, mockExecutionContext({ chunk: 1 }));
         expect(result).toEqual({ chunk: 1 });
     });
 });

--- a/test/decorators/grpc-payload.decorator.test.ts
+++ b/test/decorators/grpc-payload.decorator.test.ts
@@ -1,0 +1,23 @@
+import { ExecutionContext } from '@nestjs/common';
+import { GrpcPayload, GrpcStreamPayload } from '../../src/decorators/grpc-payload.decorator';
+
+describe('GrpcPayload decorators', () => {
+    const mockExecutionContext = (data: any): ExecutionContext => {
+        return {
+            switchToRpc: () => ({ getData: () => data }) as any,
+        } as any;
+    };
+
+    it('GrpcPayload extracts unary payload', () => {
+        const factory = (GrpcPayload as any).factory || GrpcPayload;
+        const result = factory(null, mockExecutionContext({ foo: 'bar' }));
+        expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('GrpcStreamPayload extracts stream payload', () => {
+        const factory = (GrpcStreamPayload as any).factory || GrpcStreamPayload;
+        const result = factory(null, mockExecutionContext({ chunk: 1 }));
+        expect(result).toEqual({ chunk: 1 });
+    });
+});
+

--- a/test/decorators/grpc-stream.decorator.test.ts
+++ b/test/decorators/grpc-stream.decorator.test.ts
@@ -1,0 +1,90 @@
+import { GRPC_METHOD_METADATA } from '../../src/constants';
+import { GrpcStream } from '../../src/decorators/grpc-stream.decorator';
+
+describe('GrpcStream decorator', () => {
+    it('sets metadata with inferred method name when no args provided', () => {
+        class TestController {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            streamMethod(): any {}
+        }
+
+        const descriptor: PropertyDescriptor = {
+            value: TestController.prototype.streamMethod,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        };
+
+        const decorator = GrpcStream();
+        decorator(TestController.prototype, 'streamMethod', descriptor);
+
+        const metadata = Reflect.getMetadata(
+            GRPC_METHOD_METADATA,
+            TestController.prototype,
+            'streamMethod',
+        );
+        expect(metadata).toEqual({ methodName: 'streamMethod', streaming: true });
+    });
+
+    it('sets metadata with provided string method name', () => {
+        class TestController {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            streamMethod(): any {}
+        }
+
+        const descriptor: PropertyDescriptor = {
+            value: TestController.prototype.streamMethod,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        };
+
+        const decorator = GrpcStream('CustomStream');
+        decorator(TestController.prototype, 'streamMethod', descriptor);
+
+        const metadata = Reflect.getMetadata(
+            GRPC_METHOD_METADATA,
+            TestController.prototype,
+            'streamMethod',
+        );
+        expect(metadata).toEqual({ methodName: 'CustomStream', streaming: true });
+    });
+
+    it('throws when applied to non-method', () => {
+        class TestController {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            streamMethod(): any {}
+        }
+
+        const descriptor: PropertyDescriptor = {
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        };
+
+        const decorator = GrpcStream();
+        expect(() => decorator(TestController.prototype, 'streamMethod', descriptor)).toThrow(
+            '@GrpcStream can only be applied to methods',
+        );
+    });
+
+    it('throws for empty method name', () => {
+        class TestController {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            streamMethod(): any {}
+        }
+
+        const descriptor: PropertyDescriptor = {
+            value: TestController.prototype.streamMethod,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        };
+
+        const decorator = GrpcStream({ methodName: '' });
+        expect(() => decorator(TestController.prototype, 'streamMethod', descriptor)).toThrow(
+            'Method name cannot be empty',
+        );
+    });
+});
+

--- a/test/exceptions/grpc.consumer-error-handler.test.ts
+++ b/test/exceptions/grpc.consumer-error-handler.test.ts
@@ -1,0 +1,86 @@
+import { GrpcConsumerErrorHandler } from '../../src/exceptions/grpc.exception';
+import { GrpcErrorCode } from '../../src/constants';
+
+describe('GrpcConsumerErrorHandler', () => {
+    let handler: GrpcConsumerErrorHandler;
+
+    beforeEach(() => {
+        handler = new GrpcConsumerErrorHandler();
+        jest.spyOn(Date, 'now').mockReturnValue(1000);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('handles gRPC-style error objects', () => {
+        const error = { code: GrpcErrorCode.UNAVAILABLE, message: 'down', details: 'x' };
+        const ex = handler.handleError(error, 'Svc', 'Method', 0);
+        expect(ex.getCode()).toBe(GrpcErrorCode.UNAVAILABLE);
+        expect(ex.getServiceName()).toBe('Svc');
+        expect(ex.getMethodName()).toBe('Method');
+        expect(ex.getDuration()).toBe(1000);
+        expect(ex.isRetryable()).toBe(true);
+    });
+
+    it('handles standard Error objects (retryable INTERNAL)', () => {
+        const error = new Error('boom');
+        const ex = handler.handleError(error, 'Svc', 'Method', 500);
+        expect(ex.getCode()).toBe(GrpcErrorCode.INTERNAL);
+        expect(ex.isRetryable()).toBe(true);
+    });
+
+    it('handles string errors', () => {
+        const ex = handler.handleError('ouch', 'Svc', 'Method', 250);
+        expect(ex.getCode()).toBe(GrpcErrorCode.UNKNOWN);
+        expect(ex.getDetails()).toBeUndefined();
+    });
+
+    it('handles unknown error types', () => {
+        const ex = handler.handleError({ some: 'obj' } as any, 'Svc', 'Method', 250);
+        expect(ex.getCode()).toBe(GrpcErrorCode.UNKNOWN);
+    });
+});
+
+describe('Status helpers', () => {
+    const { getGrpcStatusDescription, httpStatusToGrpcStatus } = require('../../src/exceptions/grpc.exception');
+
+    it('maps gRPC codes to descriptions', () => {
+        expect(getGrpcStatusDescription(GrpcErrorCode.OK)).toContain('Success');
+        expect(getGrpcStatusDescription(GrpcErrorCode.CANCELLED)).toContain('cancelled');
+        expect(getGrpcStatusDescription(GrpcErrorCode.INVALID_ARGUMENT)).toContain('Invalid');
+        expect(getGrpcStatusDescription(GrpcErrorCode.DEADLINE_EXCEEDED)).toContain('timeout');
+        expect(getGrpcStatusDescription(GrpcErrorCode.NOT_FOUND)).toContain('not found');
+        expect(getGrpcStatusDescription(GrpcErrorCode.ALREADY_EXISTS)).toContain('already');
+        expect(getGrpcStatusDescription(GrpcErrorCode.PERMISSION_DENIED)).toContain('Permission');
+        expect(getGrpcStatusDescription(GrpcErrorCode.RESOURCE_EXHAUSTED)).toContain('Resource');
+        expect(getGrpcStatusDescription(GrpcErrorCode.FAILED_PRECONDITION)).toContain('precondition');
+        expect(getGrpcStatusDescription(GrpcErrorCode.ABORTED)).toContain('aborted');
+        expect(getGrpcStatusDescription(GrpcErrorCode.OUT_OF_RANGE)).toContain('range');
+        expect(getGrpcStatusDescription(GrpcErrorCode.UNIMPLEMENTED)).toContain('implemented');
+        expect(getGrpcStatusDescription(GrpcErrorCode.INTERNAL)).toContain('Internal');
+        expect(getGrpcStatusDescription(GrpcErrorCode.UNAVAILABLE)).toContain('unavailable');
+        expect(getGrpcStatusDescription(GrpcErrorCode.DATA_LOSS)).toContain('Data');
+        expect(getGrpcStatusDescription(GrpcErrorCode.UNAUTHENTICATED)).toContain('Authentication');
+        expect(getGrpcStatusDescription(999)).toContain('Unknown status code');
+    });
+
+    it('maps HTTP to gRPC codes', () => {
+        expect(httpStatusToGrpcStatus(200)).toBe(GrpcErrorCode.OK);
+        expect(httpStatusToGrpcStatus(400)).toBe(GrpcErrorCode.INVALID_ARGUMENT);
+        expect(httpStatusToGrpcStatus(401)).toBe(GrpcErrorCode.UNAUTHENTICATED);
+        expect(httpStatusToGrpcStatus(403)).toBe(GrpcErrorCode.PERMISSION_DENIED);
+        expect(httpStatusToGrpcStatus(404)).toBe(GrpcErrorCode.NOT_FOUND);
+        expect(httpStatusToGrpcStatus(409)).toBe(GrpcErrorCode.ALREADY_EXISTS);
+        expect(httpStatusToGrpcStatus(412)).toBe(GrpcErrorCode.FAILED_PRECONDITION);
+        expect(httpStatusToGrpcStatus(416)).toBe(GrpcErrorCode.OUT_OF_RANGE);
+        expect(httpStatusToGrpcStatus(429)).toBe(GrpcErrorCode.RESOURCE_EXHAUSTED);
+        expect(httpStatusToGrpcStatus(499)).toBe(GrpcErrorCode.CANCELLED);
+        expect(httpStatusToGrpcStatus(500)).toBe(GrpcErrorCode.INTERNAL);
+        expect(httpStatusToGrpcStatus(501)).toBe(GrpcErrorCode.UNIMPLEMENTED);
+        expect(httpStatusToGrpcStatus(503)).toBe(GrpcErrorCode.UNAVAILABLE);
+        expect(httpStatusToGrpcStatus(504)).toBe(GrpcErrorCode.DEADLINE_EXCEEDED);
+        expect(httpStatusToGrpcStatus(418)).toBe(GrpcErrorCode.UNKNOWN);
+    });
+});
+

--- a/test/services/grpc-client.service.streams.test.ts
+++ b/test/services/grpc-client.service.streams.test.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter } from 'events';
+
+import { GrpcClientService } from '../../src/services/grpc-client.service';
+import { GrpcProtoService } from '../../src/services/grpc-proto.service';
+import { GRPC_OPTIONS } from '../../src/constants';
+import type { GrpcOptions } from '../../src/interfaces';
+
+
+jest.mock('@grpc/grpc-js', () => ({
+	credentials: {
+		createInsecure: jest.fn().mockReturnValue({}),
+		createSsl: jest.fn().mockReturnValue({}),
+	},
+}));
+
+function createStream() {
+	const ee: any = new EventEmitter();
+	ee.write = jest.fn();
+	ee.end = jest.fn(() => {
+		setImmediate(() => ee.emit('end'));
+	});
+	ee.cancel = jest.fn();
+	return ee;
+}
+
+describe('GrpcClientService streams and retry', () => {
+	let service: GrpcClientService;
+	let proto: jest.Mocked<GrpcProtoService>;
+	let options: GrpcOptions;
+
+	beforeEach(async () => {
+		options = {
+			protoPath: '/test.proto',
+			package: 'test.package',
+			url: 'localhost:50051',
+		};
+
+		proto = {
+			getProtoDefinition: jest.fn(),
+			load: jest.fn(),
+			loadService: jest.fn(),
+		} as any;
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				GrpcClientService,
+				{ provide: GRPC_OPTIONS, useValue: options },
+				{ provide: GrpcProtoService, useValue: proto },
+			],
+		}).compile();
+
+		service = module.get(GrpcClientService);
+
+		// Provide a default service constructor for stream tests
+		const ServiceCtor: any = function () {
+			(this as any).getUpdates = (_req: any) => createStream();
+			(this as any).upload = () => createStream();
+			(this as any).chat = () => createStream();
+		};
+		proto.getProtoDefinition.mockReturnValue({ NotificationService: ServiceCtor, FileService: ServiceCtor, ChatService: ServiceCtor });
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('serverStream emits data and handles end', done => {
+		const shared = createStream();
+		// Override to return shared stream
+		proto.getProtoDefinition.mockReturnValueOnce({ NotificationService: function(){ (this as any).getUpdates = () => shared; } as any });
+
+		const data: number[] = [];
+		const obs = service.serverStream<any, number>('NotificationService', 'getUpdates', {});
+		const sub = obs.subscribe({
+			next: v => {
+				data.push(v as any);
+				if (data.length === 3) {
+					try {
+						expect(data).toEqual([1, 2, 3]);
+						sub.unsubscribe();
+						done();
+					} catch (e) { done(e); }
+				}
+			},
+			error: err => done(err),
+		});
+
+		setImmediate(() => {
+			shared.emit('data', 1);
+			shared.emit('data', 2);
+			shared.emit('data', 3);
+			shared.emit('end');
+		});
+	});
+
+	it('clientStream writes input and resolves on data', async () => {
+		const shared = createStream();
+		proto.getProtoDefinition.mockReturnValueOnce({ FileService: function(){ (this as any).upload = () => shared; } as any });
+		const inputs = [ { a: 1 }, { a: 2 } ];
+		const src = {
+			subscribe: ({ next, complete }: any) => { inputs.forEach(i => next(i)); complete(); },
+		} as any;
+
+		const p = service.clientStream<any, string>('FileService', 'upload', src);
+		setImmediate(() => {
+			shared.emit('data', 'ok');
+			shared.emit('end');
+		});
+		const result = await p;
+		expect(result).toBe('ok');
+		expect(shared.write).toHaveBeenCalledTimes(2);
+	});
+
+	it('bidiStream forwards responses and ends', done => {
+		const shared = createStream();
+		proto.getProtoDefinition.mockReturnValueOnce({ ChatService: function(){ (this as any).chat = () => shared; } as any });
+		const src = {
+			subscribe: ({ next, complete }: any) => { next({ m: 'hi' }); complete(); },
+		} as any;
+		const obs = service.bidiStream<any, string>('ChatService', 'chat', src);
+		const received: string[] = [];
+		const sub = obs.subscribe({
+			next: v => { received.push(v as any); try { expect(received).toEqual(['pong']); sub.unsubscribe(); done(); } catch(e){ done(e);} },
+			error: err => done(err),
+		});
+		setImmediate(() => { shared.emit('data', 'pong'); shared.emit('end'); });
+	});
+
+	it('call retries then succeeds based on backoff', async () => {
+		// Spy on private callUnaryMethod to fail twice then succeed
+		let attempts = 0;
+		jest.spyOn<any, any>(service as any, 'callUnaryMethod').mockImplementation(() => {
+			attempts++;
+			if (attempts <= 2) {
+				return Promise.reject(new Error('fail'));
+			}
+			return Promise.resolve('done');
+		});
+		// Provide a minimal service method presence
+		const ServiceCtor: any = function () { (this as any).x = () => {}; };
+		proto.getProtoDefinition.mockReturnValue({ Svc: ServiceCtor });
+		const promise = service.call<any, any>('Svc', 'x', {}, { maxRetries: 2, retryDelay: 100 });
+		await jest.advanceTimersByTimeAsync(200);
+		const res = await promise;
+		expect(res).toBe('done');
+	});
+
+	it('validateMethod failure throws', async () => {
+		proto.getProtoDefinition.mockReturnValue({});
+		await expect(service.call<any, any>('MissingSvc', 'x', {})).rejects.toThrow('Method');
+	});
+});

--- a/test/services/grpc-client.service.streams.test.ts
+++ b/test/services/grpc-client.service.streams.test.ts
@@ -140,8 +140,7 @@ describe('GrpcClientService streams and retry', () => {
 		// Provide a minimal service method presence
 		const ServiceCtor: any = function () { (this as any).x = () => {}; };
 		proto.getProtoDefinition.mockReturnValue({ Svc: ServiceCtor });
-		const promise = service.call<any, any>('Svc', 'x', {}, { maxRetries: 2, retryDelay: 100 });
-		await jest.advanceTimersByTimeAsync(200);
+		const promise = service.call<any, any>('Svc', 'x', {}, { maxRetries: 2, retryDelay: 1 });
 		const res = await promise;
 		expect(res).toBe('done');
 	});

--- a/test/services/grpc-controller-discovery.service.test.ts
+++ b/test/services/grpc-controller-discovery.service.test.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
+
+import { GrpcControllerDiscoveryService } from '../../src/services/grpc-controller-discovery.service';
+import { GrpcRegistryService } from '../../src/services/grpc-registry.service';
+import { GRPC_CONTROLLER_METADATA, GRPC_METHOD_METADATA } from '../../src/constants';
+
+
+describe('GrpcControllerDiscoveryService', () => {
+	let service: GrpcControllerDiscoveryService;
+	let module: TestingModule;
+	let discovery: Partial<DiscoveryService>;
+	let reflector: Reflector;
+	let registry: jest.Mocked<GrpcRegistryService>;
+
+	beforeEach(async () => {
+		registry = {
+			registerController: jest.fn().mockResolvedValue(undefined),
+			getRegisteredControllers: jest.fn() as any,
+			isControllerRegistered: jest.fn() as any,
+			onModuleInit: jest.fn() as any,
+		} as any;
+
+		class HttpController {}
+		class GrpcCtrl {
+			a() {}
+			b() {}
+		}
+
+		discovery = {
+			getControllers: jest.fn().mockReturnValue([
+				{ instance: new HttpController() },
+				{ instance: new GrpcCtrl() },
+			]),
+		};
+
+		reflector = new Reflector();
+		// Apply metadata to GrpcCtrl class and its methods
+		const controllers = ((discovery as any).getControllers() as any);
+		Reflect.defineMetadata(
+			GRPC_CONTROLLER_METADATA,
+			{ serviceName: 'DiscService' },
+			controllers[1].instance.constructor,
+		);
+		const proto = controllers[1].instance.constructor.prototype;
+		proto.a = function () {};
+		proto.b = function () {};
+		Reflect.defineMetadata(GRPC_METHOD_METADATA, { methodName: 'AMethod' }, proto, 'a');
+		// leave 'b' undecorated to test inference
+
+		module = await Test.createTestingModule({
+			providers: [
+				GrpcControllerDiscoveryService,
+				MetadataScanner,
+				{ provide: DiscoveryService, useValue: discovery },
+				{ provide: Reflector, useValue: reflector },
+				{ provide: GrpcRegistryService, useValue: registry },
+			],
+		}).compile();
+
+		service = module.get(GrpcControllerDiscoveryService);
+	});
+
+	afterEach(async () => {
+		await module.close();
+		jest.clearAllMocks();
+	});
+
+	it('discovers controllers and registers with inferred and decorated methods', async () => {
+		await service.onModuleInit();
+		expect(registry.registerController).toHaveBeenCalledWith(
+			'DiscService',
+			expect.anything(),
+			expect.objectContaining({ serviceName: 'DiscService' }),
+		);
+	});
+});

--- a/test/services/grpc-provider.service.test.ts
+++ b/test/services/grpc-provider.service.test.ts
@@ -1,0 +1,185 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as grpc from '@grpc/grpc-js';
+
+import { GrpcProviderService } from '../../src/services/grpc-provider.service';
+import { GrpcProtoService } from '../../src/services/grpc-proto.service';
+import { GRPC_OPTIONS } from '../../src/constants';
+import type { GrpcOptions, ControllerMetadata } from '../../src/interfaces';
+
+jest.mock('@grpc/grpc-js', () => {
+	const serverInstance = {
+		bindAsync: jest.fn(),
+		addService: jest.fn(),
+		tryShutdown: jest.fn(),
+		forceShutdown: jest.fn(),
+		start: jest.fn(),
+	};
+	const Server = jest.fn().mockImplementation(() => serverInstance);
+	return {
+		Server,
+		ServerCredentials: {
+			createInsecure: jest.fn().mockReturnValue({}),
+			createSsl: jest.fn().mockReturnValue({}),
+		},
+		status: { INTERNAL: 13 },
+		__serverInstance: serverInstance,
+	};
+});
+
+
+describe('GrpcProviderService', () => {
+	let service: GrpcProviderService;
+	let module: TestingModule;
+	let mockProtoService: any;
+	let mockOptions: GrpcOptions;
+	let serverInstance: any;
+
+	beforeEach(async () => {
+		mockOptions = {
+			protoPath: '/path/to/service.proto',
+			package: 'test.package',
+			url: 'localhost:50051',
+			secure: false,
+		};
+
+		mockProtoService = {
+			getProtoDefinition: jest.fn(),
+			load: jest.fn().mockResolvedValue({}),
+		};
+
+		module = await Test.createTestingModule({
+			providers: [
+				GrpcProviderService,
+				{ provide: GRPC_OPTIONS, useValue: mockOptions },
+				{ provide: GrpcProtoService, useValue: mockProtoService },
+			],
+		}).compile();
+
+		service = module.get(GrpcProviderService);
+
+		// Access the shared mock server instance
+		serverInstance = (grpc as any).__serverInstance;
+	});
+
+	afterEach(async () => {
+		// Ensure server does not hang during module.close()
+		try {
+			serverInstance.tryShutdown.mockImplementation((cb: any) => cb());
+		} catch {}
+		await module.close();
+		jest.clearAllMocks();
+	});
+
+	it('starts server on module init and registers pending controllers', async () => {
+		// Arrange bindAsync success and track start flag by spying start method via server object
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(null, 50051));
+		// Ensure addService will be called via registration
+		const controllerMeta: ControllerMetadata = {
+			serviceName: 'TestService',
+			package: 'test.package',
+			methods: new Map([['Ping', { originalMethodName: 'ping', methodName: 'Ping' }]]),
+		};
+		// Make proto definition include a service constructor shape with .service
+		const serviceConstructor: any = function () {};
+		serviceConstructor.service = { originalName: { Ping: 'Ping' } };
+		mockProtoService.getProtoDefinition.mockReturnValue({ TestService: serviceConstructor });
+
+		// Pre-register a controller before server starts
+		await service.registerController('TestService', { ping: jest.fn() }, controllerMeta);
+
+		// Act
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => {
+			// Resolve immediately
+			cb(null, 50051);
+		});
+		await service.onModuleInit();
+
+		// Assert
+		expect(serverInstance.bindAsync).toHaveBeenCalled();
+		expect(serverInstance.addService).toHaveBeenCalled();
+		expect(service.isServerRunning()).toBe(true);
+	});
+
+	it('handles bind errors', async () => {
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(new Error('bind fail')));
+		await expect(service.onModuleInit()).rejects.toThrow('Failed to bind server');
+	});
+
+	it('stops server on destroy', async () => {
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(null, 50051));
+		serverInstance.tryShutdown.mockImplementation((cb: any) => cb());
+		await service.onModuleInit();
+		await service.onModuleDestroy();
+		expect(serverInstance.tryShutdown).toHaveBeenCalled();
+		expect(service.isServerRunning()).toBe(false);
+	});
+
+	it('force shutdown on shutdown error', async () => {
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(null, 50051));
+		serverInstance.tryShutdown.mockImplementation((cb: any) => cb(new Error('fail')));
+		await service.onModuleInit();
+		await service.onModuleDestroy();
+		expect(serverInstance.forceShutdown).toHaveBeenCalled();
+	});
+
+	it('createServer creates server with message size options', async () => {
+		// Recreate service with size options
+		// Avoid long shutdown time since we never started
+		await module.close();
+		mockOptions = { ...mockOptions, maxSendMessageSize: 1024, maxReceiveMessageSize: 2048 } as any;
+		module = await Test.createTestingModule({
+			providers: [
+				GrpcProviderService,
+				{ provide: GRPC_OPTIONS, useValue: mockOptions },
+				{ provide: GrpcProtoService, useValue: mockProtoService },
+			],
+		}).compile();
+		service = module.get(GrpcProviderService);
+		serverInstance = (grpc as any).__serverInstance;
+		// Trigger server creation path
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(null, 50051));
+		await service.onModuleInit();
+		// Constructor called with options
+		expect(((grpc as any).Server as jest.Mock)).toHaveBeenCalledWith({
+			'grpc.max_send_message_length': 1024,
+			'grpc.max_receive_message_length': 2048,
+		});
+	});
+
+	it('createServerCredentials returns insecure for non-secure config', () => {
+		const creds = (service as any).createServerCredentials();
+		expect(grpc.ServerCredentials.createInsecure).toHaveBeenCalled();
+		expect(creds).toBeDefined();
+	});
+
+	it('createServerCredentials throws when secure without certs', async () => {
+		await module.close();
+		mockOptions = { ...mockOptions, secure: true } as any;
+		module = await Test.createTestingModule({
+			providers: [
+				GrpcProviderService,
+				{ provide: GRPC_OPTIONS, useValue: mockOptions },
+				{ provide: GrpcProtoService, useValue: mockProtoService },
+			],
+		}).compile();
+		service = module.get(GrpcProviderService);
+		expect(() => (service as any).createServerCredentials()).toThrow('Private key and certificate chain are required');
+	});
+
+	it('validateMethods maps methods and registers service', async () => {
+		serverInstance.bindAsync.mockImplementation((_url: string, _cred: any, cb: any) => cb(null, 50051));
+		const controllerMeta: ControllerMetadata = {
+			serviceName: 'EchoService',
+			methods: new Map([
+				['Echo', { originalMethodName: 'echo', methodName: 'Echo' }],
+				['Missing', { originalMethodName: 'missing', methodName: 'Missing' }],
+			]),
+		};
+		const svcCtor: any = function () {};
+		svcCtor.service = { originalName: { Echo: 'Echo' } };
+		mockProtoService.getProtoDefinition.mockReturnValue({ EchoService: svcCtor });
+		await service.registerController('EchoService', { echo: jest.fn() }, controllerMeta);
+		await service.onModuleInit();
+		expect(serverInstance.addService).toHaveBeenCalled();
+	});
+});

--- a/test/services/grpc-registry.service.test.ts
+++ b/test/services/grpc-registry.service.test.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { GrpcRegistryService } from '../../src/services/grpc-registry.service';
+import { GrpcProviderService } from '../../src/services/grpc-provider.service';
+
+
+describe('GrpcRegistryService', () => {
+	let service: GrpcRegistryService;
+	let module: TestingModule;
+	let provider: jest.Mocked<GrpcProviderService>;
+
+	beforeEach(async () => {
+		provider = {
+			registerController: jest.fn().mockResolvedValue(undefined),
+			isServerRunning: jest.fn().mockReturnValue(true),
+			getServer: jest.fn(),
+		} as any;
+
+		module = await Test.createTestingModule({
+			providers: [GrpcRegistryService, { provide: GrpcProviderService, useValue: provider }],
+		}).compile();
+		service = module.get(GrpcRegistryService);
+	});
+
+	afterEach(async () => {
+		await module.close();
+		jest.clearAllMocks();
+	});
+
+	it('queues and registers controller via provider', async () => {
+		await service.registerController(
+			'MyService',
+			{ instance: true },
+			{ serviceName: 'MyService', methods: new Map() } as any,
+		);
+		expect(provider.registerController).toHaveBeenCalled();
+		expect(service.isControllerRegistered('MyService')).toBe(true);
+		const all = service.getRegisteredControllers();
+		expect(all.has('MyService')).toBe(true);
+	});
+
+	it('processes pending registrations on init', async () => {
+		// Spy on internal process method via onModuleInit path
+		await expect(service.onModuleInit()).resolves.toBeUndefined();
+	});
+});

--- a/test/utils/logger.test.ts
+++ b/test/utils/logger.test.ts
@@ -88,9 +88,22 @@ describe('GrpcLogger', () => {
             expect(perfLogger).toBeDefined();
         });
 
+        it('should log performance with custom context', () => {
+            const perfLogger = new GrpcLogger({ logPerformance: true, context: 'Base' });
+            // Use a different context to hit the branch with context override
+            perfLogger.performance('Step', 10, 'Other');
+            expect(perfLogger).toBeDefined();
+        });
+
         it('should log details when enabled', () => {
             const detailLogger = new GrpcLogger({ logDetails: true });
             detailLogger.detail('Detail message', { key: 'value' });
+            expect(detailLogger).toBeDefined();
+        });
+
+        it('should log details without data and with custom context', () => {
+            const detailLogger = new GrpcLogger({ logDetails: true, context: 'Main' });
+            detailLogger.detail('No data', undefined, 'Sub');
             expect(detailLogger).toBeDefined();
         });
 
@@ -108,6 +121,16 @@ describe('GrpcLogger', () => {
             const perfLogger = new GrpcLogger({ logPerformance: true });
             perfLogger.methodCall('testMethod', 'TestService', 100);
             expect(perfLogger).toBeDefined();
+        });
+
+        it('should log debug/verbose/log/warn with custom context', () => {
+            const l = new GrpcLogger({ level: 'debug', context: 'Ctx' });
+            l.debug('d', 'Other');
+            l.verbose('v', 'Other');
+            l.log('l', 'Other');
+            l.warn('w', 'Other');
+            l.error('e', 'err', 'Other');
+            expect(l).toBeDefined();
         });
 
         it('should log connection events', () => {


### PR DESCRIPTION
Start the gRPC server after binding to resolve connection establishment failures.

The gRPC server was being bound to an address but was not explicitly started, preventing it from listening for incoming connections. This PR adds the `server.start()` call to ensure the server is fully operational after binding and registering controllers.

---
<a href="https://cursor.com/background-agent?bcId=bc-d89f8135-8f08-45b4-bcc5-836ef37b5173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d89f8135-8f08-45b4-bcc5-836ef37b5173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

